### PR TITLE
bulleted lists -> code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,45 +4,45 @@ Adds support for a themes based compiling process whereby a master theme is used
 
 Example brunch project with themeing
 
-+ PROJECT FOLDER  
-    - app  
-        - /base (this is the master theme)
-            - /sass
-            - /js
-        - /theme2   
-            - /sass
-            - /js
-        - /theme3
-            - /sass
-            - /js
-        - ...  
-    - node_modules  
-    - brunch-config.coffee  
-    - package.json  
-    - ...  
+    PROJECT FOLDER  
+      app  
+          /base (this is the master theme)
+              /sass
+              /js
+          /theme2   
+              /sass
+              /js
+          /theme3
+              /sass
+              /js
+          ...  
+      node_modules  
+      brunch-config.coffee  
+      package.json  
+      ...  
 
 If a file of the same name exists in another theme other than 'base' then that file will replace the file in base when compiling the css file for that theme (imports as well).
 
 For example
 
-+ PROJECT FOLDER  
-    - app  
-        - /base (this is the master theme)
-            - /sass  
-                - /partials
-                    - _header.scss  
-                - base.scss (this file imports _header.scss using import) 
-        - /theme2 
-            - /sass  
-                - /partials
-                    - _header.scss (custom _header.scss file)
+    PROJECT FOLDER  
+      app  
+          /base (this is the master theme)
+              /sass  
+                  /partials
+                      _header.scss  
+                  base.scss (this file imports _header.scss using import) 
+          /theme2 
+              /sass  
+                  /partials
+                      _header.scss (custom _header.scss file)
 
 Then base.scss is rendered for each theme:  
 
-+ FOR base 
-    - {output-folder}/base.css (import uses the header.scss file located in base theme when import is referenced) 
-+ FOR theme2  
-    - {output-folder}/base.css (import uses the header.scss file located in theme2 theme when import is referenced)  
+    FOR base 
+        {output-folder}/base.css (import uses the header.scss file located in base theme when import is referenced) 
+    FOR theme2  
+        {output-folder}/base.css (import uses the header.scss file located in theme2 theme when import is referenced)  
 
 Known Issues  
 + ~~Currently file import substition only works with scss not sass due to pattern matching error~~


### PR DESCRIPTION
Bullets don't look too good for these places, so replaced with code blocks instead.

Although, the `FOR` section should probably have the `()s` moved to make those lines shorter. However, haven't decided how best to handle that. Therefore, this commit is limited to simply converting to code blocks.
